### PR TITLE
Fix Option Scene Load

### DIFF
--- a/OptionsMenu/OptionsButtons.gd
+++ b/OptionsMenu/OptionsButtons.gd
@@ -1,7 +1,8 @@
 extends Button
 
 func _ready():
-	$VBoxContainer/SonicSpeedButton.pressed = Global.sonic_speed
+	self.pressed = Global.sonic_speed
+	#$VBoxContainer/SonicSpeedButton.pressed = 
 	print("bing")
 
 func _on_FullScreenButton_pressed():


### PR DESCRIPTION
The issue was that because the script was attached to the button, not the scene root, so it couldn't access $VBoxContainer/SonicSpeedButton. It's looking for a child of the node the script is attached to.
Changed to "self" and it works.